### PR TITLE
Ignore enums directory when running black so we can have nice spacing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [tool.black]
 line-length = 88
 target-version = ['py312']
+extend-exclude='''
+(src/app/enums/.*)
+'''
 
 [tool.mypy]
 packages = ["."]

--- a/src/app/enums/operating_systems.py
+++ b/src/app/enums/operating_systems.py
@@ -4,66 +4,67 @@ from enum import Enum
 class OpenLabsOS(Enum):
     """OpenLabs supported OS."""
 
-    DEBIAN_11 = "debian_11"  # Debian 11
-    DEBIAN_12 = "debian_12"  # Debian 12
-    UBUNTU_20 = "ubuntu_20"  # Debian 20.04
-    UBUNTU_22 = "ubuntu_22"  # Ubuntu 22.04
-    UBUNTU_24 = "ubuntu_24"  # Ubuntu 24.04
-    SUSE_12 = "suse_12"  # SUSE 12
-    SUSE_15 = "suse_15"  # SUSE 15
+    DEBIAN_11      = "debian_11"    # Debian 11
+    DEBIAN_12      = "debian_12"    # Debian 12
+    UBUNTU_20      = "ubuntu_20"    # Debian 20.04
+    UBUNTU_22      = "ubuntu_22"    # Ubuntu 22.04
+    UBUNTU_24      = "ubuntu_24"    # Ubuntu 24.04
+    SUSE_12        = "suse_12"      # SUSE 12
+    SUSE_15        = "suse_15"      # SUSE 15
     # CENTOS_9       = "centos_9"     # CentOS Stream 9
     # CENTOS_10      = "centos_10"    # CentOS Stream 10
-    KALI = "kali"  # Kali Linux
-    WINDOWS_10 = "windows_10"  # Windows 10
-    WINDOWS_11 = "windows_11"  # Windows 11
-    WINDOWS_2016 = "windows_2016"  # Windows Server 2016
-    WINDOWS_2019 = "windows_2019"  # Windows Server 2019
-    WINDOWS_2022 = "windows_2022"  # Windows Server 2022
+    KALI           = "kali"         # Kali Linux
+    WINDOWS_10     = "windows_10"   # Windows 10
+    WINDOWS_11     = "windows_11"   # Windows 11
+    WINDOWS_2016   = "windows_2016" # Windows Server 2016
+    WINDOWS_2019   = "windows_2019" # Windows Server 2019
+    WINDOWS_2022   = "windows_2022" # Windows Server 2022
 
 
 # Using AWS ami
 AWS_OS_MAP = {
     # Debian - https://wiki.debian.org/Cloud/AmazonEC2Image
-    OpenLabsOS.DEBIAN_11: "ami-053413bdacb39d8dc",
-    OpenLabsOS.DEBIAN_12: "ami-0e8087266e36fe754",
+    OpenLabsOS.DEBIAN_11    : "ami-053413bdacb39d8dc",
+    OpenLabsOS.DEBIAN_12    : "ami-0e8087266e36fe754",
     # Ubuntu - https://cloud-images.ubuntu.com/locator/ec2/
-    OpenLabsOS.UBUNTU_20: "ami-014f7ab33242ea43c",
-    OpenLabsOS.UBUNTU_22: "ami-0e1bed4f06a3b463d",
-    OpenLabsOS.UBUNTU_24: "ami-04b4f1a9cf54c11d0",
+    OpenLabsOS.UBUNTU_20    : "ami-014f7ab33242ea43c",
+    OpenLabsOS.UBUNTU_22    : "ami-0e1bed4f06a3b463d",
+    OpenLabsOS.UBUNTU_24    : "ami-04b4f1a9cf54c11d0",
     # SUSE
-    OpenLabsOS.SUSE_12: "ami-0d6a3fb3bfdd87b52",
-    OpenLabsOS.SUSE_15: "ami-0d9f9dbae7b9a241d",
+    OpenLabsOS.SUSE_12      : "ami-0d6a3fb3bfdd87b52",
+    OpenLabsOS.SUSE_15      : "ami-0d9f9dbae7b9a241d",
     # CentOS - https://www.centos.org/download/aws-images/
     # OpenLabsOS.CENTOS_9     : "ami-0705f7887207411ca"
     # OpenLabsOS.CENTOS_10    : "ami-03753625d82454d04"
     # Kali - https://aws.amazon.com/marketplace/server/configuration?productId=804fcc46-63fc-4eb6-85a1-50e66d6c7215
-    OpenLabsOS.KALI: "ami-02be3d7604aff56a7",
+    OpenLabsOS.KALI         : "ami-02be3d7604aff56a7",
     # Windows
-    OpenLabsOS.WINDOWS_2016: "ami-032ec7a32b7fb247c",
-    OpenLabsOS.WINDOWS_2019: "ami-049dd04cca2dc5594",
-    OpenLabsOS.WINDOWS_2022: "ami-0a0ebee827a585d06",
+    OpenLabsOS.WINDOWS_2016 : "ami-032ec7a32b7fb247c",
+    OpenLabsOS.WINDOWS_2019 : "ami-049dd04cca2dc5594",
+    OpenLabsOS.WINDOWS_2022 : "ami-0a0ebee827a585d06",
 }
 
 
 # URN formatted as <publisher>:<offer>:<sku>:<version>
 AZURE_OS_MAP = {
     # Debian - https://wiki.debian.org/Cloud/MicrosoftAzure
-    OpenLabsOS.DEBIAN_11: "Debian:debian-11:11-backports-gen2:latest",
-    OpenLabsOS.DEBIAN_12: "Debian:debian-12:12-gen2:latest",
+    OpenLabsOS.DEBIAN_11    : "Debian:debian-11:11-backports-gen2:latest",
+    OpenLabsOS.DEBIAN_12    : "Debian:debian-12:12-gen2:latest",
     # Ubuntu - https://documentation.ubuntu.com/azure/en/latest/azure-how-to/instances/find-ubuntu-images/
-    OpenLabsOS.UBUNTU_20: "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest",
-    OpenLabsOS.UBUNTU_22: "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest",
-    OpenLabsOS.UBUNTU_24: "Canonical:ubuntu-24_04-lts:server:latest",
+    OpenLabsOS.UBUNTU_20    : "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest",
+    OpenLabsOS.UBUNTU_22    : "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest",
+    OpenLabsOS.UBUNTU_24    : "Canonical:ubuntu-24_04-lts:server:latest",
     # SUSE
-    OpenLabsOS.SUSE_12: "SUSE:sles-12-sp5:gen2:latest",
-    OpenLabsOS.SUSE_15: "SUSE:sles-15-sp5:gen2:latest",
+    OpenLabsOS.SUSE_12      : "SUSE:sles-12-sp5:gen2:latest",
+    OpenLabsOS.SUSE_15      : "SUSE:sles-15-sp5:gen2:latest",
     # CentOS
     # OpenLabsOS.CENTOS_9     : ""
     # OpenLabsOS.CENTOS_10    : ""
     # Kali
-    OpenLabsOS.KALI: "kali-linux:kali:kali-2024-4:2024.4.1",
+    OpenLabsOS.KALI         : "kali-linux:kali:kali-2024-4:2024.4.1",
     # Windows
-    OpenLabsOS.WINDOWS_2016: "MicrosoftWindowsServer:WindowsServer:2016-datacenter-gensecond:latest",
-    OpenLabsOS.WINDOWS_2019: "MicrosoftWindowsServer:WindowsServer:2019-datacenter-gensecond:latest",
-    OpenLabsOS.WINDOWS_2022: "MicrosoftWindowsServer:WindowsServer:2022-datacenter-g2:latest",
+    OpenLabsOS.WINDOWS_2016 : "MicrosoftWindowsServer:WindowsServer:2016-datacenter-gensecond:latest",
+    OpenLabsOS.WINDOWS_2019 : "MicrosoftWindowsServer:WindowsServer:2019-datacenter-gensecond:latest",
+    OpenLabsOS.WINDOWS_2022 : "MicrosoftWindowsServer:WindowsServer:2022-datacenter-g2:latest",
 }
+

--- a/src/app/enums/specs.py
+++ b/src/app/enums/specs.py
@@ -4,28 +4,28 @@ from enum import Enum
 class OpenLabsSpec(Enum):
     """OpenLabs VM hardware specifications."""
 
-    TINY = "tiny"
-    SMALL = "small"
+    TINY   = "tiny"
+    SMALL  = "small"
     MEDIUM = "medium"
-    LARGE = "large"
-    HUGE = "huge"
+    LARGE  = "large"
+    HUGE   = "huge"
 
 
 # https://aws.amazon.com/ec2/instance-types/t2/
 AWS_SPEC_MAP = {
-    OpenLabsSpec.TINY: "t2.nano",  # 1 vCPU, 0.5 GiB RAM
-    OpenLabsSpec.SMALL: "t2.small",  # 1 vCPU, 2.0 GiB RAM
-    OpenLabsSpec.MEDIUM: "t2.medium",  # 2 vCPU, 4.0 GiB RAM
-    OpenLabsSpec.LARGE: "t2.large",  # 2 vCPU, 8.0 GiB RAM
-    OpenLabsSpec.HUGE: "t2.xlarge",  # 4 vCPU, 16.0 GiB RAM
+    OpenLabsSpec.TINY   : "t2.nano",   # 1 vCPU, 0.5 GiB RAM
+    OpenLabsSpec.SMALL  : "t2.small",  # 1 vCPU, 2.0 GiB RAM
+    OpenLabsSpec.MEDIUM : "t2.medium", # 2 vCPU, 4.0 GiB RAM
+    OpenLabsSpec.LARGE  : "t2.large",  # 2 vCPU, 8.0 GiB RAM
+    OpenLabsSpec.HUGE   : "t2.xlarge", # 4 vCPU, 16.0 GiB RAM
 }
 
 
 # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/bv1-series?tabs=sizebasic
 AZURE_SPEC_MAP = {
-    OpenLabsSpec.TINY: "Standard_B1ls2",  # 1 vCPU, 0.5 GiB RAM
-    OpenLabsSpec.SMALL: "Standard_B1ms",  # 1 vCPU, 2.0 GiB RAM
-    OpenLabsSpec.MEDIUM: "Standard_B2s",  # 2 vCPU, 4.0 GiB RAM
-    OpenLabsSpec.LARGE: "Standard_B2ms",  # 2 vCPU, 8.0 GiB RAM
-    OpenLabsSpec.HUGE: "Standard_B4ms",  # 4 vCPU, 16.0 GiB RAM
+    OpenLabsSpec.TINY   : "Standard_B1ls2", # 1 vCPU, 0.5 GiB RAM
+    OpenLabsSpec.SMALL  : "Standard_B1ms",  # 1 vCPU, 2.0 GiB RAM
+    OpenLabsSpec.MEDIUM : "Standard_B2s",   # 2 vCPU, 4.0 GiB RAM
+    OpenLabsSpec.LARGE  : "Standard_B2ms",  # 2 vCPU, 8.0 GiB RAM
+    OpenLabsSpec.HUGE   : "Standard_B4ms",  # 4 vCPU, 16.0 GiB RAM
 }


### PR DESCRIPTION
## Checklist

- [x] I have added a version label to my PR (e.g., patch, minor, major).
- [x] I have tested my changes locally and verified they work as expected.
- [x] I have added relevant tests to cover my changes.
- [x] I have made any necessary updates to the documentation.

## Description

- Modify `pyproject.toml` to ignore enums directory in API
- Add spacing back to operating system and specs enums so adding to them will be easier in the future
