### PR TITLE
Add debug docker config to work with vscode debugging extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,4 +172,5 @@ cython_debug/
 
 # Editor swap file
 *.swp
-.vscode
+.vscode/*
+!.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Remote Attach to OpenLabs API",
+      "type": "python",
+      "request": "attach",
+      "connect": {
+        "host": "localhost",
+        "port": 5678
+      },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}/src",
+          "remoteRoot": "/code/src"
+        }
+      ]
+    }
+  ]
+}

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,12 +14,6 @@ RUN pip install --no-cache-dir debugpy
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
-#COPY src /code/src
-#COPY .env /code/.env
-
-# For dynamic versioning
-COPY .git /code/.git
-
 EXPOSE 80
 
 CMD ["uvicorn", "src.app.main:app", "--host", "0.0.0.0", "--port", "80", "--reload"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,25 @@
+FROM python:3.12-slim
+
+WORKDIR /code
+
+# For dynamic versioning
+RUN apt-get update && apt-get install -y git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install debugpy for debugging
+RUN pip install --no-cache-dir debugpy
+
+# Install python dependencies
+COPY ./requirements.txt /code/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+
+#COPY src /code/src
+#COPY .env /code/.env
+
+# For dynamic versioning
+COPY .git /code/.git
+
+EXPOSE 80
+
+CMD ["uvicorn", "src.app.main:app", "--host", "0.0.0.0", "--port", "80", "--reload"]

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ POSTGRES_DEBUG_PORT=5432  # Expose PostgreSQL on host port for debugging
 ## Run with Docker
 
 **Prerequisites**
-- Install [Docker](https://docs.docker.com/engine/install/) and `docker-compose`.
+- Install [Docker](https://docs.docker.com/engine/install/) and `docker compose`.
 
 **Steps**
 
 1) Build and Run Containers:
 
     ```bash
-    docker-compose up
+    docker compose up
     ```
     > **Note:** If you get a `KeyError: 'ContainerConfig'` error, run `docker container prune -f` to remove stopped containers.
 
@@ -208,7 +208,7 @@ You can configure Black to format on save (`Ctrl`+`S`) with the following config
 To debug with the python debugger extension, use the `docker-compose.dev.yaml` file.
 
 ```bash
-docker-compose -f docker-compose.dev.yml up
+docker compose -f docker-compose.dev.yml up
 ```
 
 The app will only be started once you run the debugger in VScode.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 ## Table of Contents
 
 1. [Developer Quickstart](#developer-quickstart)
-1. [Tests](#tests)
-1. [Project Structure](#project-structure)
-1. [VScode Extensions](#vscode-extensions)
-1. [Debugging](#debugging)
-1. [Workflows](#workflows)
-1. [Contributing](/CONTRIBUTING.md)
-1. [License](/LICENSE)
+2. [Tests](#tests)
+3. [Project Structure](#project-structure)
+4. [VScode Extensions](#vscode-extensions)
+5. [Debugging](#debugging)
+6. [Workflows](#workflows)
+7. [Contributing](/CONTRIBUTING.md)
+8. [License](/LICENSE)
 
 ## Developer Quickstart
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 ## Table of Contents
 
 1. [Developer Quickstart](#developer-quickstart)
-2. [Tests](#tests)
-3. [Project Structure](#project-structure)
-4. [VScode Extensions](#vscode-extensions)
-5. [Workflows](#workflows)
-6. [Contributing](/CONTRIBUTING.md)
-7. [License](/LICENSE)
+1. [Tests](#tests)
+1. [Project Structure](#project-structure)
+1. [VScode Extensions](#vscode-extensions)
+1. [Debugging](#debugging)
+1. [Workflows](#workflows)
+1. [Contributing](/CONTRIBUTING.md)
+1. [License](/LICENSE)
 
 ## Developer Quickstart
 
@@ -25,7 +26,7 @@ Create a `.env` file in the project root. This file configures both FastAPI and 
 # PostgreSQL Configuration
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
-POSTGRES_SERVER=postgres
+POSTGRES_SERVER=postgres # localhost if launching without Docker
 POSTGRES_PORT=5432
 POSTGRES_DB=openlabsx
 
@@ -201,6 +202,18 @@ You can configure Black to format on save (`Ctrl`+`S`) with the following config
     "editor.formatOnSave": true
   }
 ```
+
+## Debugging
+
+To debug with the python debugger extension, use the `docker-compose.dev.yaml` file.
+
+```bash
+docker-compose -f docker-compose.dev.yml up
+```
+
+The app will only be started once you run the debugger in VScode.
+
+All changes made to code in your local directory will be applied to the container app and should reload automatically.
 
 ## Workflows
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,45 @@
+services:
+  postgres:
+    image: postgres:17
+    container_name: postgres_db_openlabsx
+    env_file:
+      - .env
+    ports:
+      - "${POSTGRES_DEBUG_PORT}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - fastapi_network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  fastapi:
+    build:
+      dockerfile: Dockerfile.dev
+    container_name: fastapi_app
+    env_file:
+      - .env
+    volumes:
+      - .:/code
+    ports:
+      - "8000:80"
+      - "5678:5678"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - fastapi_network
+    command: [
+      "python", "-m", "debugpy", "--listen", "0.0.0.0:5678", "--wait-for-client",
+      "-m", "uvicorn", "src.app.main:app", "--host", "0.0.0.0", "--port", "80", "--reload"
+    ]
+
+volumes:
+  postgres_data:
+
+networks:
+  fastapi_network:
+    driver: bridge

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,11 +16,11 @@ services:
       timeout: 5s
       retries: 5
 
-  fastapi:
+  fastapi_dev:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    container_name: fastapi_app
+    container_name: fastapi_app_dev
     env_file:
       - .env
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,7 @@ services:
 
   fastapi:
     build:
+      context: .
       dockerfile: Dockerfile.dev
     container_name: fastapi_app
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   fastapi:
     build:
+      context: .
       dockerfile: Dockerfile
     container_name: fastapi_app
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       retries: 5
 
   fastapi:
-    build: .
+    build:
+      dockerfile: Dockerfile
     container_name: fastapi_app
     env_file:
       - .env


### PR DESCRIPTION
## Checklist

- [x] I have added a version label to my PR (e.g., patch, minor, major).
- [x] I have tested my changes locally and verified they work as expected.
- [x] I have added relevant tests to cover my changes.
- [x] I have made any necessary updates to the documentation.

## Description
- Add debug docker-compose and dockerfile
- Allow `.vscode/launch.json` for debugging to be committed
- Add documentation section to readme
- Clarify server name for .env in docs
- Use `docker compose` instead of `docker-compose` in README

Fixes: #28 