### PR TITLE
Specify minimum disk size for each OS

### DIFF
--- a/src/app/enums/operating_systems.py
+++ b/src/app/enums/operating_systems.py
@@ -14,8 +14,6 @@ class OpenLabsOS(Enum):
     # CENTOS_9       = "centos_9"     # CentOS Stream 9
     # CENTOS_10      = "centos_10"    # CentOS Stream 10
     KALI           = "kali"         # Kali Linux
-    WINDOWS_10     = "windows_10"   # Windows 10
-    WINDOWS_11     = "windows_11"   # Windows 11
     WINDOWS_2016   = "windows_2016" # Windows Server 2016
     WINDOWS_2019   = "windows_2019" # Windows Server 2019
     WINDOWS_2022   = "windows_2022" # Windows Server 2022

--- a/src/app/enums/operating_systems.py
+++ b/src/app/enums/operating_systems.py
@@ -76,3 +76,17 @@ AZURE_OS_MAP = {
     OpenLabsOS.WINDOWS_2022 : "MicrosoftWindowsServer:WindowsServer:2022-datacenter-g2:latest",
 }
 
+
+
+OS_SIZE_THRESHOLD = {
+    OpenLabsOS.DEBIAN_11    : 8,
+    OpenLabsOS.DEBIAN_12    : 8,
+    OpenLabsOS.UBUNTU_20    : 8,
+    OpenLabsOS.UBUNTU_22    : 8,
+    OpenLabsOS.SUSE_12      : 8,
+    OpenLabsOS.SUSE_15      : 8,
+    OpenLabsOS.KALI         : 32,
+    OpenLabsOS.WINDOWS_2016 : 32,
+    OpenLabsOS.WINDOWS_2019 : 32,
+    OpenLabsOS.WINDOWS_2022 : 32,
+}

--- a/src/app/enums/operating_systems.py
+++ b/src/app/enums/operating_systems.py
@@ -76,8 +76,7 @@ AZURE_OS_MAP = {
     OpenLabsOS.WINDOWS_2022 : "MicrosoftWindowsServer:WindowsServer:2022-datacenter-g2:latest",
 }
 
-
-
+# Minimum size allowed for host given an OS
 OS_SIZE_THRESHOLD = {
     OpenLabsOS.DEBIAN_11    : 8,
     OpenLabsOS.DEBIAN_12    : 8,

--- a/src/app/enums/operating_systems.py
+++ b/src/app/enums/operating_systems.py
@@ -26,18 +26,23 @@ AWS_OS_MAP = {
     # Debian - https://wiki.debian.org/Cloud/AmazonEC2Image
     OpenLabsOS.DEBIAN_11    : "ami-053413bdacb39d8dc",
     OpenLabsOS.DEBIAN_12    : "ami-0e8087266e36fe754",
+
     # Ubuntu - https://cloud-images.ubuntu.com/locator/ec2/
     OpenLabsOS.UBUNTU_20    : "ami-014f7ab33242ea43c",
     OpenLabsOS.UBUNTU_22    : "ami-0e1bed4f06a3b463d",
     OpenLabsOS.UBUNTU_24    : "ami-04b4f1a9cf54c11d0",
+
     # SUSE
     OpenLabsOS.SUSE_12      : "ami-0d6a3fb3bfdd87b52",
     OpenLabsOS.SUSE_15      : "ami-0d9f9dbae7b9a241d",
+
     # CentOS - https://www.centos.org/download/aws-images/
     # OpenLabsOS.CENTOS_9     : "ami-0705f7887207411ca"
     # OpenLabsOS.CENTOS_10    : "ami-03753625d82454d04"
+
     # Kali - https://aws.amazon.com/marketplace/server/configuration?productId=804fcc46-63fc-4eb6-85a1-50e66d6c7215
     OpenLabsOS.KALI         : "ami-02be3d7604aff56a7",
+
     # Windows
     OpenLabsOS.WINDOWS_2016 : "ami-032ec7a32b7fb247c",
     OpenLabsOS.WINDOWS_2019 : "ami-049dd04cca2dc5594",
@@ -50,18 +55,23 @@ AZURE_OS_MAP = {
     # Debian - https://wiki.debian.org/Cloud/MicrosoftAzure
     OpenLabsOS.DEBIAN_11    : "Debian:debian-11:11-backports-gen2:latest",
     OpenLabsOS.DEBIAN_12    : "Debian:debian-12:12-gen2:latest",
+
     # Ubuntu - https://documentation.ubuntu.com/azure/en/latest/azure-how-to/instances/find-ubuntu-images/
     OpenLabsOS.UBUNTU_20    : "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest",
     OpenLabsOS.UBUNTU_22    : "Canonical:0001-com-ubuntu-server-jammy:22_04-lts-gen2:latest",
     OpenLabsOS.UBUNTU_24    : "Canonical:ubuntu-24_04-lts:server:latest",
+
     # SUSE
     OpenLabsOS.SUSE_12      : "SUSE:sles-12-sp5:gen2:latest",
     OpenLabsOS.SUSE_15      : "SUSE:sles-15-sp5:gen2:latest",
+
     # CentOS
     # OpenLabsOS.CENTOS_9     : ""
     # OpenLabsOS.CENTOS_10    : ""
+
     # Kali
     OpenLabsOS.KALI         : "kali-linux:kali:kali-2024-4:2024.4.1",
+
     # Windows
     OpenLabsOS.WINDOWS_2016 : "MicrosoftWindowsServer:WindowsServer:2016-datacenter-gensecond:latest",
     OpenLabsOS.WINDOWS_2019 : "MicrosoftWindowsServer:WindowsServer:2019-datacenter-gensecond:latest",

--- a/src/app/validators/network.py
+++ b/src/app/validators/network.py
@@ -1,5 +1,6 @@
 import re
 
+from ..enums.operating_systems import OpenLabsOS, OS_SIZE_THRESHOLD
 
 def is_valid_hostname(hostname: str) -> bool:
     """Check if string is a valid hostname based on RRFC 1035.
@@ -32,3 +33,19 @@ def is_valid_hostname(hostname: str) -> bool:
 
     allowed = re.compile(r"(?!-)[a-z0-9-]{1,63}(?<!-)$", re.IGNORECASE)
     return all(allowed.match(label) for label in labels)
+
+def is_valid_disk_size(os: OpenLabsOS, size: int) -> bool:
+    """Check if size for given OS is possible.
+
+    Args:
+    ----
+        os (OpenLabsOS): Operating system of host to check.
+        size (int): Size of disk requested.
+
+    Returns:
+    -------
+        bool: True if possible host size. False otherwise
+
+    """
+
+    return size >= OS_SIZE_THRESHOLD[os]

--- a/tests/validators/test_network.py
+++ b/tests/validators/test_network.py
@@ -36,13 +36,13 @@ def test_invalid_hostnames() -> None:
     ]
 
     for hostname in invalid_hostnames:
-        assert is_valid_hostname(hostname)
+        assert not is_valid_hostname(hostname)
 
 
 def test_hostname_with_trailing_dot() -> None:
     """Test hostname with a trailing dot."""
     assert is_valid_hostname("example.com.")
-    assert is_valid_hostname("example..com.")
+    assert not is_valid_hostname("example..com.")
 
 
 def test_hostname_length_limits() -> None:
@@ -53,12 +53,12 @@ def test_hostname_length_limits() -> None:
     invalid_hostname = valid_hostname + "a"
 
     assert is_valid_hostname(valid_hostname[:-2])
-    assert is_valid_hostname(invalid_hostname)
+    assert not is_valid_hostname(invalid_hostname)
 
 
 def test_numeric_tld() -> None:
     """Test hostnames with numeric TLDs."""
-    assert is_valid_hostname("example.123")
+    assert not is_valid_hostname("example.123")
     assert is_valid_hostname("123.example")
 
 def test_valid_host_size() -> None:

--- a/tests/validators/test_network.py
+++ b/tests/validators/test_network.py
@@ -1,5 +1,5 @@
-from src.app.validators.network import is_valid_hostname
-
+from src.app.validators.network import is_valid_hostname, is_valid_disk_size
+from src.app.enums.operating_systems import OpenLabsOS
 
 def test_valid_hostnames() -> None:
     """Test valid hostnames."""
@@ -62,3 +62,9 @@ def test_numeric_tld() -> None:
     """Test hostnames with numeric TLDs."""
     assert is_valid_hostname("example.123") is False
     assert is_valid_hostname("123.example") is True
+
+def test_valid_host_size() -> None:
+    """Test host disk size minimums."""
+    assert is_valid_disk_size(OpenLabsOS.DEBIAN_11, 10)
+    assert is_valid_disk_size(OpenLabsOS.WINDOWS_2016, 32)
+    assert not is_valid_disk_size(OpenLabsOS.WINDOWS_2016, 10)

--- a/tests/validators/test_network.py
+++ b/tests/validators/test_network.py
@@ -17,7 +17,7 @@ def test_valid_hostnames() -> None:
     ]
 
     for hostname in valid_hostnames:
-        assert is_valid_hostname(hostname) is True
+        assert is_valid_hostname(hostname)
 
 
 def test_invalid_hostnames() -> None:
@@ -36,13 +36,13 @@ def test_invalid_hostnames() -> None:
     ]
 
     for hostname in invalid_hostnames:
-        assert is_valid_hostname(hostname) is False
+        assert is_valid_hostname(hostname)
 
 
 def test_hostname_with_trailing_dot() -> None:
     """Test hostname with a trailing dot."""
-    assert is_valid_hostname("example.com.") is True
-    assert is_valid_hostname("example..com.") is False
+    assert is_valid_hostname("example.com.")
+    assert is_valid_hostname("example..com.")
 
 
 def test_hostname_length_limits() -> None:
@@ -52,16 +52,14 @@ def test_hostname_length_limits() -> None:
     )  # Total length = 63*4 + 3 dots = 255 (valid without trailing dot)
     invalid_hostname = valid_hostname + "a"
 
-    assert (
-        is_valid_hostname(valid_hostname[:-2]) is True
-    )  # Adjust to fit within 253 limit
-    assert is_valid_hostname(invalid_hostname) is False
+    assert is_valid_hostname(valid_hostname[:-2])
+    assert is_valid_hostname(invalid_hostname)
 
 
 def test_numeric_tld() -> None:
     """Test hostnames with numeric TLDs."""
-    assert is_valid_hostname("example.123") is False
-    assert is_valid_hostname("123.example") is True
+    assert is_valid_hostname("example.123")
+    assert is_valid_hostname("123.example")
 
 def test_valid_host_size() -> None:
     """Test host disk size minimums."""


### PR DESCRIPTION
## Checklist

- [x] I have added a version label to my PR (e.g., patch, minor, major).
- [x] I have tested my changes locally and verified they work as expected.
- [x] I have added relevant tests to cover my changes.
- [x] I have made any necessary updates to the documentation.

## Description

- Add dict to specify minimum disk size for each OS
- Add validator to validate size field in host schema (TODO). not implemented yet while waiting for SQL ORM branch to be merged
- Add test for validator
- Remove Windows 10 and 11 OS bc of licensing issues that would prevent us from having those AMIs
- Fix some spacing issues in OS enum
- Make assertions more concise to fit with ruff (and my) ideology 

Fixes: #31, #33 