### PR TITLE
Add template delete endpoints

### DIFF
--- a/src/app/crud/crud_host_templates.py
+++ b/src/app/crud/crud_host_templates.py
@@ -1,3 +1,5 @@
+import logging
+
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -10,6 +12,8 @@ from ..schemas.template_host_schema import (
     TemplateHostSchema,
 )
 from ..schemas.template_subnet_schema import TemplateSubnetID
+
+logger = logging.getLogger(__name__)
 
 
 async def get_host_template_headers(
@@ -98,3 +102,28 @@ async def create_host_template(
         await db.refresh(host_obj)
 
     return host_obj
+
+
+async def delete_host_template(db: AsyncSession, host_model: TemplateHostModel) -> bool:
+    """Delete a standalone host template.
+
+    Only allows deletion if the host template is standalone (i.e. subnet_id is None).
+
+    Args:
+    ----
+        db (Sessions): Database connection.
+        host_model (TemplateHostModel): Host template model object.
+
+    Returns:
+    -------
+        bool: True if successfully delete. False otherwise.
+
+    """
+    if not host_model.is_standalone():
+        log_msg = "Cannot delete host template because it is not a standalone template."
+        logger.error(log_msg)
+        return False
+
+    await db.delete(host_model)
+    await db.commit()
+    return True

--- a/src/app/crud/crud_subnet_templates.py
+++ b/src/app/crud/crud_subnet_templates.py
@@ -1,3 +1,5 @@
+import logging
+
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -11,6 +13,8 @@ from ..schemas.template_subnet_schema import (
 )
 from ..schemas.template_vpc_schema import TemplateVPCID
 from .crud_host_templates import create_host_template
+
+logger = logging.getLogger(__name__)
 
 
 async def get_subnet_template_headers(
@@ -114,3 +118,32 @@ async def create_subnet_template(
         await db.refresh(subnet_obj)
 
     return subnet_obj
+
+
+async def delete_subnet_template(
+    db: AsyncSession, subnet_model: TemplateSubnetModel
+) -> bool:
+    """Delete a standalone subnet template.
+
+    Only allows deletion if the subnet template is standalone (i.e. vpc_id is None).
+
+    Args:
+    ----
+        db (Sessions): Database connection.
+        subnet_model (TemplateSubnetModel): Subnet template model object.
+
+    Returns:
+    -------
+        bool: True if successfully delete. False otherwise.
+
+    """
+    if not subnet_model.is_standalone():
+        log_msg = (
+            "Cannot delete subnet template because it is not a standalone template."
+        )
+        logger.error(log_msg)
+        return False
+
+    await db.delete(subnet_model)
+    await db.commit()
+    return True

--- a/src/app/crud/crud_vpc_templates.py
+++ b/src/app/crud/crud_vpc_templates.py
@@ -1,3 +1,5 @@
+import logging
+
 from sqlalchemy import inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -12,6 +14,8 @@ from ..schemas.template_vpc_schema import (
     TemplateVPCSchema,
 )
 from .crud_subnet_templates import create_subnet_template
+
+logger = logging.getLogger(__name__)
 
 
 async def get_vpc_template_headers(
@@ -119,3 +123,29 @@ async def create_vpc_template(
         await db.refresh(vpc_obj)
 
     return vpc_obj
+
+
+async def delete_vpc_template(db: AsyncSession, vpc_model: TemplateVPCModel) -> bool:
+    """Delete a standalone subnet template.
+
+    Only allows deletion if the subnet template is standalone (i.e. vpc_id is None).
+
+    Args:
+    ----
+        db (Sessions): Database connection.
+        vpc_model (TemplateVPCModel): Subnet template model object.
+
+    Returns:
+    -------
+        bool: True if successfully delete. False otherwise.
+
+    """
+    if not vpc_model.is_standalone():
+        log_msg = "Cannot delete VPC template because it is not a standalone template."
+        logger.error(log_msg)
+
+        return False
+
+    await db.delete(vpc_model)
+    await db.commit()
+    return True

--- a/src/app/models/template_base_model.py
+++ b/src/app/models/template_base_model.py
@@ -4,7 +4,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, MappedAsDataclass, mapped_column
 
 
-class OpenLabsTemplateMixin(MappedAsDataclass):
+class TemplateModelMixin(MappedAsDataclass):
     """Mixin to provide a UUID for each template-based model."""
 
     id: Mapped[uuid.UUID] = mapped_column(

--- a/src/app/models/template_host_model.py
+++ b/src/app/models/template_host_model.py
@@ -31,3 +31,15 @@ class TemplateHostModel(Base, OpenLabsTemplateMixin):
     )
 
     tags: Mapped[list[str]] = mapped_column(ARRAY(String), default_factory=list)
+
+    def is_standalone(self) -> bool:
+        """Return whether host template model is a standalone model.
+
+        Standalone means that the template is not part of a larger template.
+
+        Returns
+        -------
+            bool: True if standalone. False otherwise.
+
+        """
+        return self.subnet_id is None

--- a/src/app/models/template_host_model.py
+++ b/src/app/models/template_host_model.py
@@ -7,10 +7,10 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ..core.db.database import Base
 from ..enums.operating_systems import OpenLabsOS
 from ..enums.specs import OpenLabsSpec
-from .template_base_model import OpenLabsTemplateMixin
+from .template_base_model import TemplateModelMixin
 
 
-class TemplateHostModel(Base, OpenLabsTemplateMixin):
+class TemplateHostModel(Base, TemplateModelMixin):
     """SQLAlchemy ORM model for template host."""
 
     __tablename__ = "host_templates"

--- a/src/app/models/template_range_model.py
+++ b/src/app/models/template_range_model.py
@@ -22,3 +22,16 @@ class TemplateRangeModel(Base, TemplateModelMixin):
     vpcs = relationship(
         "TemplateVPCModel", back_populates="range", cascade="all, delete-orphan"
     )
+
+    def is_standalone(self) -> bool:
+        """Return whether host template model is a standalone model.
+
+        Standalone means that the template is not part of a larger template.
+
+        Returns
+        -------
+            bool: True if standalone. False otherwise.
+
+        """
+        # Ranges are currently the highest level template object
+        return True

--- a/src/app/models/template_range_model.py
+++ b/src/app/models/template_range_model.py
@@ -3,10 +3,10 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..core.db.database import Base
 from ..enums.providers import OpenLabsProvider
-from .template_base_model import OpenLabsTemplateMixin
+from .template_base_model import TemplateModelMixin
 
 
-class TemplateRangeModel(Base, OpenLabsTemplateMixin):
+class TemplateRangeModel(Base, TemplateModelMixin):
     """SQLAlchemy ORM model for template range objects."""
 
     __tablename__ = "range_templates"

--- a/src/app/models/template_subnet_model.py
+++ b/src/app/models/template_subnet_model.py
@@ -5,10 +5,10 @@ from sqlalchemy.dialects.postgresql import CIDR, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..core.db.database import Base
-from .template_base_model import OpenLabsTemplateMixin
+from .template_base_model import TemplateModelMixin
 
 
-class TemplateSubnetModel(Base, OpenLabsTemplateMixin):
+class TemplateSubnetModel(Base, TemplateModelMixin):
     """SQLAlchemy ORM model for template subnet objects."""
 
     __tablename__ = "subnet_templates"
@@ -31,3 +31,15 @@ class TemplateSubnetModel(Base, OpenLabsTemplateMixin):
     hosts = relationship(
         "TemplateHostModel", back_populates="subnet", cascade="all, delete-orphan"
     )
+
+    def is_standalone(self) -> bool:
+        """Return whether subnet template model is a standalone model.
+
+        Standalone means that the template is not part of a larger template.
+
+        Returns
+        -------
+            bool: True if standalone. False otherwise.
+
+        """
+        return self.vpc_id is None

--- a/src/app/models/template_vpc_model.py
+++ b/src/app/models/template_vpc_model.py
@@ -32,3 +32,15 @@ class TemplateVPCModel(Base, TemplateModelMixin):
     subnets = relationship(
         "TemplateSubnetModel", back_populates="vpc", cascade="all, delete-orphan"
     )
+
+    def is_standalone(self) -> bool:
+        """Return whether vpc template model is a standalone model.
+
+        Standalone means that the template is not part of a larger template.
+
+        Returns
+        -------
+            bool: True if standalone. False otherwise.
+
+        """
+        return self.range_id is None

--- a/src/app/models/template_vpc_model.py
+++ b/src/app/models/template_vpc_model.py
@@ -6,10 +6,10 @@ from sqlalchemy.dialects.postgresql import CIDR, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from ..core.db.database import Base
-from .template_base_model import OpenLabsTemplateMixin
+from .template_base_model import TemplateModelMixin
 
 
-class TemplateVPCModel(Base, OpenLabsTemplateMixin):
+class TemplateVPCModel(Base, TemplateModelMixin):
     """SQLAlchemy ORM model for template vpc objects."""
 
     __tablename__ = "vpc_templates"

--- a/tests/api/v1/test_templates.py
+++ b/tests/api/v1/test_templates.py
@@ -540,6 +540,124 @@ async def test_template_subnet_get_nonexistent_subnet(client: AsyncClient) -> No
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
+async def test_template_subnet_delete(client: AsyncClient) -> None:
+    """Test that we can sucessfully delete a subnet template."""
+    response = await client.post(
+        f"{BASE_ROUTE}/templates/subnets", json=valid_subnet_payload
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    subnet_id = response.json()["id"]
+
+    # Delete host
+    response = await client.delete(f"{BASE_ROUTE}/templates/subnets/{subnet_id}")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() is True  # Strict check for true
+
+    # Check that host is no longer in database
+    response = await client.get(f"{BASE_ROUTE}/templates/subnets/{subnet_id}")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_template_subnet_delete_invalid_uuid(client: AsyncClient) -> None:
+    """Test that we get a 400 when providing an invalid UUID4."""
+    invalid_uuid = str(uuid.uuid4())[:-1]
+    response = await client.delete(f"{BASE_ROUTE}/templates/subnets/{invalid_uuid}")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "uuid" in str(response.json()["detail"]).lower()
+
+
+async def test_template_subnet_delete_non_existent(client: AsyncClient) -> None:
+    """Test that we get a 404 when trying to delete a nonexistent subnet template."""
+    random_uuid = str(uuid.uuid4())
+    response = await client.delete(f"{BASE_ROUTE}/templates/subnets/{random_uuid}")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_template_subnet_delete_non_standalone(client: AsyncClient) -> None:
+    """Test that we get a 409 when trying to delete a non-standalone subnet template."""
+    # Get all existing subnets
+    response = await client.get(f"{BASE_ROUTE}/templates/subnets?standalone_only=false")
+
+    if response.status_code == status.HTTP_200_OK:
+        existing_subnet_template_id = [subnet["id"] for subnet in response.json()]
+    elif response.status_code == status.HTTP_404_NOT_FOUND:
+        existing_subnet_template_id = []
+    else:
+        pytest.fail(f"Unknown status code: {response.status_code} recieved!")
+
+    # Add a VPC template
+    response = await client.post(f"{BASE_ROUTE}/templates/vpcs", json=valid_vpc_payload)
+    assert response.status_code == status.HTTP_200_OK
+
+    # Find new subnet template
+    response = await client.get(f"{BASE_ROUTE}/templates/subnets?standalone_only=false")
+    assert response.status_code == status.HTTP_200_OK
+
+    new_subnet_template_id = ""
+    for subnet in response.json():
+        if subnet["id"] not in existing_subnet_template_id:
+            new_subnet_template_id = subnet["id"]
+            break
+    assert new_subnet_template_id
+
+    # Try to delete non-standalone host template
+    response = await client.delete(
+        f"{BASE_ROUTE}/templates/subnets/{new_subnet_template_id}"
+    )
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert "standalone" in str(response.json()["detail"]).lower()
+
+
+async def test_template_subnet_delete_cascade_hosts(client: AsyncClient) -> None:
+    """Test that when we delete a subnet template it cascades and deletes the associated hosts."""
+    # Get all existing hosts
+    response = await client.get(f"{BASE_ROUTE}/templates/hosts?standalone_only=false")
+
+    if response.status_code == status.HTTP_200_OK:
+        existing_host_template_id = [host["id"] for host in response.json()]
+    elif response.status_code == status.HTTP_404_NOT_FOUND:
+        existing_host_template_id = []
+    else:
+        pytest.fail(f"Unknown status code: {response.status_code} recieved!")
+
+    # Add a subnet template
+    response = await client.post(
+        f"{BASE_ROUTE}/templates/subnets", json=valid_subnet_payload
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    subnet_id = response.json()["id"]
+
+    # Find new host template
+    response = await client.get(f"{BASE_ROUTE}/templates/hosts?standalone_only=false")
+    assert response.status_code == status.HTTP_200_OK
+
+    new_host_template_id = ""
+    for host in response.json():
+        if host["id"] not in existing_host_template_id:
+            new_host_template_id = host["id"]
+            break
+    assert new_host_template_id
+
+    # Delete standalone subnet template
+    response = await client.delete(f"{BASE_ROUTE}/templates/subnets/{subnet_id}")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() is True  # Strict check for true
+
+    # Check to see if the dependent host template was also removed
+    response = await client.get(f"{BASE_ROUTE}/templates/hosts?standalone_only=false")
+
+    if response.status_code == status.HTTP_200_OK:
+        leftover_host_template_ids = [host["id"] for host in response.json()]
+    elif response.status_code == status.HTTP_404_NOT_FOUND:
+        leftover_host_template_ids = []
+    else:
+        pytest.fail(f"Unknown status code: {response.status_code} recieved!")
+
+    assert new_host_template_id not in leftover_host_template_ids
+
+
 async def test_template_host_valid_payload(client: AsyncClient) -> None:
     """Test that we get a 200 reponse and a valid uuid.UUID4 in response."""
     response = await client.post(

--- a/tests/api/v1/test_templates.py
+++ b/tests/api/v1/test_templates.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import status
 from httpx import AsyncClient
 
+from src.app.models.template_range_model import TemplateRangeModel
 from src.app.schemas.template_host_schema import TemplateHostSchema
 from src.app.schemas.template_subnet_schema import TemplateSubnetHeaderSchema
 
@@ -183,6 +184,9 @@ async def test_template_host_get_non_empty_list(client: AsyncClient) -> None:
 
     expected = json.loads(host_header_obj.model_dump_json())
     assert expected in response_json
+
+
+###### Order no longer matters ######
 
 
 async def test_template_range_valid_payload(client: AsyncClient) -> None:
@@ -365,6 +369,183 @@ async def test_template_range_host_size_too_small(client: AsyncClient) -> None:
     # Request
     response = await client.post(f"{BASE_ROUTE}/templates/ranges", json=invalid_payload)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+async def test_template_range_delete(client: AsyncClient) -> None:
+    """Test that we can sucessfully delete a range template."""
+    response = await client.post(
+        f"{BASE_ROUTE}/templates/ranges", json=valid_range_payload
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    range_id = response.json()["id"]
+
+    # Delete range
+    response = await client.delete(f"{BASE_ROUTE}/templates/ranges/{range_id}")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() is True  # Strict check for true
+
+    # Check that range is no longer in database
+    response = await client.get(f"{BASE_ROUTE}/templates/ranges/{range_id}")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_template_range_delete_invalid_uuid(client: AsyncClient) -> None:
+    """Test that we get a 400 when providing an invalid UUID4."""
+    invalid_uuid = str(uuid.uuid4())[:-1]
+    response = await client.delete(f"{BASE_ROUTE}/templates/ranges/{invalid_uuid}")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "uuid" in str(response.json()["detail"]).lower()
+
+
+async def test_template_ramge_delete_non_existent(client: AsyncClient) -> None:
+    """Test that we get a 404 when trying to delete a nonexistent range template."""
+    random_uuid = str(uuid.uuid4())
+    response = await client.delete(f"{BASE_ROUTE}/templates/ranges/{random_uuid}")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+async def test_template_range_delete_non_standalone(
+    monkeypatch: pytest.MonkeyPatch, client: AsyncClient
+) -> None:
+    """Test that we get a 409 when trying to delete a non-standalone range template.
+
+    **Note:** When this test was written, ranges could never be non-standalone. Ranges
+    were the highest level template and as a result the is_standalone() method was
+    hardcoded to always return True for compatibility. This is why the method is mocked.
+    """
+    # Patch range model method to return False
+    monkeypatch.setattr(TemplateRangeModel, "is_standalone", lambda self: False)
+
+    # Add a range template
+    response = await client.post(
+        f"{BASE_ROUTE}/templates/ranges", json=valid_range_payload
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    range_id = response.json()["id"]
+
+    # Delete range
+    response = await client.delete(f"{BASE_ROUTE}/templates/ranges/{range_id}")
+    assert response.status_code == status.HTTP_409_CONFLICT
+    assert "standalone" in str(response.json()["detail"]).lower()
+
+
+async def test_template_range_delete_cascade_vpcs_subnets_and_hosts(
+    client: AsyncClient,
+) -> None:
+    """Test that when we delete a range template it cascades and deletes the associated vpcs, subnets, and hosts."""
+    # Get all existing hosts
+    response = await client.get(f"{BASE_ROUTE}/templates/hosts?standalone_only=false")
+
+    if response.status_code == status.HTTP_200_OK:
+        existing_host_template_id = [host["id"] for host in response.json()]
+    elif response.status_code == status.HTTP_404_NOT_FOUND:
+        existing_host_template_id = []
+    else:
+        pytest.fail(f"Unknown status code: {response.status_code} recieved!")
+
+    # Get all existing subnets
+    response = await client.get(f"{BASE_ROUTE}/templates/subnets?standalone_only=false")
+
+    if response.status_code == status.HTTP_200_OK:
+        existing_subnet_template_id = [subnet["id"] for subnet in response.json()]
+    elif response.status_code == status.HTTP_404_NOT_FOUND:
+        existing_subnet_template_id = []
+    else:
+        pytest.fail(f"Unknown status code: {response.status_code} recieved!")
+
+    # Get all existing vpcs
+    response = await client.get(f"{BASE_ROUTE}/templates/vpcs?standalone_only=false")
+
+    if response.status_code == status.HTTP_200_OK:
+        existing_vpc_template_id = [vpc["id"] for vpc in response.json()]
+    elif response.status_code == status.HTTP_404_NOT_FOUND:
+        existing_vpc_template_id = []
+    else:
+        pytest.fail(f"Unknown status code: {response.status_code} recieved!")
+
+    # Add a range template
+    response = await client.post(
+        f"{BASE_ROUTE}/templates/ranges", json=valid_range_payload
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    range_id = response.json()["id"]
+
+    # Find new vpc template
+    response = await client.get(f"{BASE_ROUTE}/templates/vpcs?standalone_only=false")
+    assert response.status_code == status.HTTP_200_OK
+
+    new_vpc_template_id = ""
+    for vpc in response.json():
+        if vpc["id"] not in existing_vpc_template_id:
+            new_vpc_template_id = vpc["id"]
+            break
+    assert new_vpc_template_id
+
+    # Find new subnet template
+    response = await client.get(f"{BASE_ROUTE}/templates/subnets?standalone_only=false")
+    assert response.status_code == status.HTTP_200_OK
+
+    new_subnet_template_id = ""
+    for subnet in response.json():
+        if subnet["id"] not in existing_subnet_template_id:
+            new_subnet_template_id = subnet["id"]
+            break
+    assert new_subnet_template_id
+
+    # Find new host template
+    response = await client.get(f"{BASE_ROUTE}/templates/hosts?standalone_only=false")
+    assert response.status_code == status.HTTP_200_OK
+
+    new_host_template_id = ""
+    for host in response.json():
+        if host["id"] not in existing_host_template_id:
+            new_host_template_id = host["id"]
+            break
+    assert new_host_template_id
+
+    # Delete standalone range template
+    response = await client.delete(f"{BASE_ROUTE}/templates/ranges/{range_id}")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() is True  # Strict check for true
+
+    # Check to see if dependent vpc template was removed
+    response = await client.get(f"{BASE_ROUTE}/templates/vpcs?standalone_only=false")
+
+    if response.status_code == status.HTTP_200_OK:
+        leftover_vpc_template_ids = [vpc["id"] for vpc in response.json()]
+    elif response.status_code == status.HTTP_404_NOT_FOUND:
+        leftover_vpc_template_ids = []
+    else:
+        pytest.fail(f"Unknown status code: {response.status_code} recieved!")
+
+    assert new_vpc_template_id not in leftover_vpc_template_ids
+
+    # Check to see if dependent subnet template was removed
+    response = await client.get(f"{BASE_ROUTE}/templates/subnets?standalone_only=false")
+
+    if response.status_code == status.HTTP_200_OK:
+        leftover_subnet_template_ids = [subnet["id"] for subnet in response.json()]
+    elif response.status_code == status.HTTP_404_NOT_FOUND:
+        leftover_subnet_template_ids = []
+    else:
+        pytest.fail(f"Unknown status code: {response.status_code} recieved!")
+
+    assert new_subnet_template_id not in leftover_subnet_template_ids
+
+    # Check to see if the dependent host template was removed
+    response = await client.get(f"{BASE_ROUTE}/templates/hosts?standalone_only=false")
+
+    if response.status_code == status.HTTP_200_OK:
+        leftover_host_template_ids = [host["id"] for host in response.json()]
+    elif response.status_code == status.HTTP_404_NOT_FOUND:
+        leftover_host_template_ids = []
+    else:
+        pytest.fail(f"Unknown status code: {response.status_code} recieved!")
+
+    assert new_host_template_id not in leftover_host_template_ids
 
 
 async def test_template_vpc_valid_payload(client: AsyncClient) -> None:

--- a/tests/crud/__init__.py
+++ b/tests/crud/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for OpenLabs API crud operations."""

--- a/tests/crud/crud_mocks.py
+++ b/tests/crud/crud_mocks.py
@@ -1,0 +1,43 @@
+# Dummy DB session for testing
+from unittest.mock import AsyncMock
+
+
+class DummyDB:
+    """Dummy database class for testing."""
+
+    def __init__(self) -> None:
+        """Initialize dummy db."""
+        self.delete = AsyncMock()
+        self.commit = AsyncMock()
+
+
+class DummyTemplateHost:
+    """Dummy host template model for testing."""
+
+    def is_standalone(self) -> bool:
+        """Return dummy standalone state."""
+        return True
+
+
+class DummyTemplateSubnet:
+    """Dummy template subnet model for testing."""
+
+    def is_standalone(self) -> bool:
+        """Return dummy standalone state."""
+        return True
+
+
+class DummyTemplateVPC:
+    """Dummy template VPC model for testing."""
+
+    def is_standalone(self) -> bool:
+        """Return dummy standalone state."""
+        return True
+
+
+class DummyTemplateRange:
+    """Dummy template range model for testing."""
+
+    def is_standalone(self) -> bool:
+        """Return dummy standalone state."""
+        return True

--- a/tests/crud/test_crud_host_templates.py
+++ b/tests/crud/test_crud_host_templates.py
@@ -16,7 +16,7 @@ async def test_no_delete_non_standalone_host_templates(
     monkeypatch.setattr(dummy_host, "is_standalone", lambda: False)
 
     result = await delete_host_template(dummy_db, dummy_host)  # type: ignore
-    assert result is False  # Stick check
+    assert result is False  # Strict check
 
     # Verify that delete and commit were not called
     dummy_db.delete.assert_not_called()

--- a/tests/crud/test_crud_host_templates.py
+++ b/tests/crud/test_crud_host_templates.py
@@ -1,0 +1,23 @@
+import pytest
+
+from src.app.crud.crud_host_templates import delete_host_template
+
+from .crud_mocks import DummyDB, DummyTemplateHost
+
+
+async def test_no_delete_non_standalone_host_templates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that delete_host_template() returns false when host template is not standalone."""
+    dummy_db = DummyDB()
+
+    # Patch host model is_standalone() method to always return False
+    dummy_host = DummyTemplateHost()
+    monkeypatch.setattr(dummy_host, "is_standalone", lambda: False)
+
+    result = await delete_host_template(dummy_db, dummy_host)  # type: ignore
+    assert result is False  # Stick check
+
+    # Verify that delete and commit were not called
+    dummy_db.delete.assert_not_called()
+    dummy_db.commit.assert_not_called()

--- a/tests/crud/test_crud_range_templates.py
+++ b/tests/crud/test_crud_range_templates.py
@@ -16,7 +16,7 @@ async def test_no_delete_non_standalone_range_templates(
     monkeypatch.setattr(dummy_range, "is_standalone", lambda: False)
 
     result = await delete_range_template(dummy_db, dummy_range)  # type: ignore
-    assert result is False  # Stick check
+    assert result is False  # Strict check
 
     # Verify that delete and commit were not called
     dummy_db.delete.assert_not_called()

--- a/tests/crud/test_crud_range_templates.py
+++ b/tests/crud/test_crud_range_templates.py
@@ -1,0 +1,23 @@
+import pytest
+
+from src.app.crud.crud_range_templates import delete_range_template
+
+from .crud_mocks import DummyDB, DummyTemplateRange
+
+
+async def test_no_delete_non_standalone_range_templates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that delete_range_template() returns false when range template is not standalone."""
+    dummy_db = DummyDB()
+
+    # Patch host model is_standalone() method to always return False
+    dummy_range = DummyTemplateRange()
+    monkeypatch.setattr(dummy_range, "is_standalone", lambda: False)
+
+    result = await delete_range_template(dummy_db, dummy_range)  # type: ignore
+    assert result is False  # Stick check
+
+    # Verify that delete and commit were not called
+    dummy_db.delete.assert_not_called()
+    dummy_db.commit.assert_not_called()

--- a/tests/crud/test_crud_subnet_templates.py
+++ b/tests/crud/test_crud_subnet_templates.py
@@ -1,0 +1,23 @@
+import pytest
+
+from src.app.crud.crud_subnet_templates import delete_subnet_template
+
+from .crud_mocks import DummyDB, DummyTemplateSubnet
+
+
+async def test_no_delete_non_standalone_subnet_templates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that delete_subnet_template() returns false when subnet template is not standalone."""
+    dummy_db = DummyDB()
+
+    # Patch host model is_standalone() method to always return False
+    dummy_subnet = DummyTemplateSubnet()
+    monkeypatch.setattr(dummy_subnet, "is_standalone", lambda: False)
+
+    result = await delete_subnet_template(dummy_db, dummy_subnet)  # type: ignore
+    assert result is False  # Stick check
+
+    # Verify that delete and commit were not called
+    dummy_db.delete.assert_not_called()
+    dummy_db.commit.assert_not_called()

--- a/tests/crud/test_crud_subnet_templates.py
+++ b/tests/crud/test_crud_subnet_templates.py
@@ -16,7 +16,7 @@ async def test_no_delete_non_standalone_subnet_templates(
     monkeypatch.setattr(dummy_subnet, "is_standalone", lambda: False)
 
     result = await delete_subnet_template(dummy_db, dummy_subnet)  # type: ignore
-    assert result is False  # Stick check
+    assert result is False  # Strict check
 
     # Verify that delete and commit were not called
     dummy_db.delete.assert_not_called()

--- a/tests/crud/test_crud_vpc_templates.py
+++ b/tests/crud/test_crud_vpc_templates.py
@@ -16,7 +16,7 @@ async def test_no_delete_non_standalone_vpc_templates(
     monkeypatch.setattr(dummy_vpc, "is_standalone", lambda: False)
 
     result = await delete_vpc_template(dummy_db, dummy_vpc)  # type: ignore
-    assert result is False  # Stick check
+    assert result is False  # Strict check
 
     # Verify that delete and commit were not called
     dummy_db.delete.assert_not_called()

--- a/tests/crud/test_crud_vpc_templates.py
+++ b/tests/crud/test_crud_vpc_templates.py
@@ -1,0 +1,23 @@
+import pytest
+
+from src.app.crud.crud_vpc_templates import delete_vpc_template
+
+from .crud_mocks import DummyDB, DummyTemplateVPC
+
+
+async def test_no_delete_non_standalone_vpc_templates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that delete_vpc_template() returns false when VPC template is not standalone."""
+    dummy_db = DummyDB()
+
+    # Patch host model is_standalone() method to always return False
+    dummy_vpc = DummyTemplateVPC()
+    monkeypatch.setattr(dummy_vpc, "is_standalone", lambda: False)
+
+    result = await delete_vpc_template(dummy_db, dummy_vpc)  # type: ignore
+    assert result is False  # Stick check
+
+    # Verify that delete and commit were not called
+    dummy_db.delete.assert_not_called()
+    dummy_db.commit.assert_not_called()

--- a/tests/validators/test_id.py
+++ b/tests/validators/test_id.py
@@ -1,4 +1,5 @@
 import uuid
+from random import randint
 
 from src.app.validators.id import is_valid_uuid4
 
@@ -15,3 +16,9 @@ def test_invalid_uuid4() -> None:
     for _ in range(5):
         invalid_uuid = str(uuid.uuid4())[:-1]
         assert not is_valid_uuid4(invalid_uuid)
+
+
+def test_wrong_uuid_version_uuid4() -> None:
+    """Test that we get false for the wrong UUID version."""
+    uuid3_str = str(uuid.uuid1(randint(0, 100), randint(0, 100)))  # noqa: S311
+    assert not is_valid_uuid4(uuid3_str)


### PR DESCRIPTION
## Checklist

- [x] I have added a version label to my PR (e.g., patch, minor, major).
- [x] I have tested my changes locally and verified they work as expected.
- [x] I have added relevant tests to cover my changes.
- [x] I have made any necessary updates to the documentation.

## Description

This PR adds delete endpoints for all of the existing template objects: `range`, `vpc`, `subnet`, and `host`. All the endpoints are located at `DELETE /api/v1/templates/{TEMPLATE_TYPE}/{UUID}`. 

Tests were added to verify that deletes will cascade and delete all sub templates. For example, if you delete a range template, all VPCs, subnets, and hosts part of that range template will also be deleted from the database.

This addresses part of #53. The modification endpoints will be made in a separate PR.